### PR TITLE
Implement directory watcher module with test coverage

### DIFF
--- a/ods/core/__init__.py
+++ b/ods/core/__init__.py
@@ -11,9 +11,11 @@ except Exception:  # pragma: no cover
 
 from .config import Config
 from .database import Database
+from .watcher import DirectoryWatcher
 
 __all__ = [
     "DocumentClassificationWorkflow",
     "Config",
     "Database",
+    "DirectoryWatcher",
 ]

--- a/ods/core/watcher.py
+++ b/ods/core/watcher.py
@@ -1,0 +1,64 @@
+"""Directory watcher module
+
+Provides a simple wrapper around ``watchdog`` to monitor a directory for
+file changes. When a file is created or modified, a callback is invoked
+with the path to the changed file.
+
+This implements the "文件夹监听" feature described in the project plan.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Optional
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+
+class DirectoryWatcher(FileSystemEventHandler):
+    """Watch a directory and notify on file changes.
+
+    Parameters
+    ----------
+    directory: str
+        Path to the directory that should be watched.
+    callback: Callable[[str], None]
+        Function called with the path of a file whenever it is created or
+        modified within the directory tree.
+    recursive: bool, optional
+        Whether to watch sub-directories as well. Defaults to ``True``.
+    """
+
+    def __init__(self, directory: str, callback: Callable[[str], None], *, recursive: bool = True) -> None:
+        self._path = str(Path(directory))
+        self._callback = callback
+        self._observer = Observer()
+        self._recursive = recursive
+
+    # ------------------------------------------------------------------
+    # FileSystemEventHandler methods
+    # ------------------------------------------------------------------
+    def on_created(self, event):  # pragma: no cover - exercised via integration test
+        if not event.is_directory:
+            self._callback(event.src_path)
+
+    def on_modified(self, event):  # pragma: no cover - exercised via integration test
+        if not event.is_directory:
+            self._callback(event.src_path)
+
+    # ------------------------------------------------------------------
+    # Observer control methods
+    # ------------------------------------------------------------------
+    def start(self) -> None:
+        """Start watching the directory."""
+        self._observer.schedule(self, self._path, recursive=self._recursive)
+        self._observer.start()
+
+    def stop(self) -> None:
+        """Stop watching the directory."""
+        self._observer.stop()
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        """Wait until the observer thread finishes."""
+        self._observer.join(timeout)

--- a/tests/test_directory_watcher.py
+++ b/tests/test_directory_watcher.py
@@ -1,0 +1,26 @@
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+from ods.core.watcher import DirectoryWatcher
+
+
+def test_directory_watcher_triggers_callback(tmp_path):
+    """DirectoryWatcher should invoke callback when a file is created."""
+    callback = Mock()
+    watcher = DirectoryWatcher(str(tmp_path), callback)
+
+    try:
+        watcher.start()
+        # Create a new file inside the watched directory
+        test_file = tmp_path / "example.txt"
+        test_file.write_text("hello")
+
+        # Give the watcher a moment to process the event
+        time.sleep(1)
+    finally:
+        watcher.stop()
+        watcher.join()
+
+    # Ensure callback was invoked with the created file path
+    assert any(str(test_file) == call.args[0] for call in callback.call_args_list)


### PR DESCRIPTION
## Summary
- add `DirectoryWatcher` to monitor filesystem changes
- expose watcher via core package
- cover watcher with integration test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad080c08d483218b19c92f9586ab68